### PR TITLE
Fix compatibility issues with Python 3.12 and modern library versions

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -4,7 +4,7 @@ import cv2
 import numpy as np
 import torch
 import torch.utils.data
-
+from albumentations.augmentations import transforms
 
 class Dataset(torch.utils.data.Dataset):
     def __init__(self, img_ids, img_dir, mask_dir, img_ext, mask_ext, num_classes, transform=None):
@@ -67,10 +67,10 @@ class Dataset(torch.utils.data.Dataset):
             augmented = self.transform(image=img, mask=mask)
             img = augmented['image']
             mask = augmented['mask']
-        
-        img = img.astype('float32') / 255
-        img = img.transpose(2, 0, 1)
+        if self.transform and not any(isinstance(t, transforms.Normalize) for t in self.transform):
+            img = img.astype('float32') / 255
         mask = mask.astype('float32') / 255
+        img = img.transpose(2, 0, 1)
         mask = mask.transpose(2, 0, 1)
         
         return img, mask, {'img_id': img_id}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
-albumentations
+numpy<2
+albumentations==2.0.6
+torch==2.2.2
+torchvision==0.17.2
+tqdm
+pandas
+scikit-learn

--- a/train.py
+++ b/train.py
@@ -9,6 +9,7 @@ import torch.backends.cudnn as cudnn
 import torch.nn as nn
 import torch.optim as optim
 import yaml
+from albumentations import augmentations
 from albumentations.augmentations import transforms
 from albumentations.core.composition import Compose, OneOf
 from sklearn.model_selection import train_test_split
@@ -250,19 +251,18 @@ def main():
     train_img_ids, val_img_ids = train_test_split(img_ids, test_size=0.2, random_state=41)
 
     train_transform = Compose([
-        transforms.RandomRotate90(),
-        transforms.Flip(),
+        augmentations.RandomRotate90(),
+        augmentations.HorizontalFlip(),
         OneOf([
             transforms.HueSaturationValue(),
-            transforms.RandomBrightness(),
-            transforms.RandomContrast(),
+            augmentations.RandomBrightnessContrast(),
         ], p=1),
-        transforms.Resize(config['input_h'], config['input_w']),
+        augmentations.Resize(config['input_h'], config['input_w']),
         transforms.Normalize(),
     ])
 
     val_transform = Compose([
-        transforms.Resize(config['input_h'], config['input_w']),
+        augmentations.Resize(config['input_h'], config['input_w']),
         transforms.Normalize(),
     ])
 

--- a/val.py
+++ b/val.py
@@ -31,6 +31,7 @@ def parse_args():
 
 def main():
     args = parse_args()
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
     with open('models/%s/config.yml' % args.name, 'r') as f:
         config = yaml.load(f, Loader=yaml.FullLoader)
@@ -48,7 +49,7 @@ def main():
                                            config['input_channels'],
                                            config['deep_supervision'])
 
-    model = model.cuda()
+    model = model.to(device)
 
     # Data loading code
     img_ids = glob(os.path.join('inputs', config['dataset'], 'images', '*' + config['img_ext']))
@@ -86,8 +87,8 @@ def main():
         os.makedirs(os.path.join('outputs', config['name'], str(c)), exist_ok=True)
     with torch.no_grad():
         for input, target, meta in tqdm(val_loader, total=len(val_loader)):
-            input = input.cuda()
-            target = target.cuda()
+            input = input.to(device)
+            target = target.to(device)
 
             # compute output
             if config['deep_supervision']:

--- a/val.py
+++ b/val.py
@@ -6,6 +6,7 @@ import cv2
 import torch
 import torch.backends.cudnn as cudnn
 import yaml
+from albumentations import augmentations
 from albumentations.augmentations import transforms
 from albumentations.core.composition import Compose
 from sklearn.model_selection import train_test_split
@@ -60,7 +61,7 @@ def main():
     model.eval()
 
     val_transform = Compose([
-        transforms.Resize(config['input_h'], config['input_w']),
+        augmentations.Resize(config['input_h'], config['input_w']),
         transforms.Normalize(),
     ])
 


### PR DESCRIPTION
Thanks for your great work on this repository!

In this PR, I applied the following modifications to support Python 3.12 and updated dependencies:

- **requirements.txt**  
  Added required libraries with version specifications.

- **train.py / val.py**  
  1. Updated import statements and usage to be compatible with `albumentations==2.0.6`.  
  2. Added logic to use GPU only if available.

- **dataset.py**  
  If `self.transform` includes `Normalize()`, skip dividing image pixels by 255.0.

---

**NOTE:**  
This modification is **not backward compatible** and may cause errors when used with older library versions.
